### PR TITLE
Corrige incompatibilidade do ChromaDB com NumPy 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ flask==2.3.3
 langchain==0.3.26
 langchain-community==0.3.27
 langchain-ollama==0.3.3
-chromadb==0.4.24
+chromadb==0.4.28
 numpy>=2.1.0


### PR DESCRIPTION
## Summary
- atualiza `chromadb` no `requirements.txt` para a versão 0.4.28 compatível com NumPy 2

## Testing
- `python -m py_compile app.py log_suporte.py`


------
https://chatgpt.com/codex/tasks/task_e_686ec8ef5bdc833291ce9ada5ca72021