### PR TITLE
Fix numpy 2.x compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,11 @@ from langchain.prompts import PromptTemplate
 from log_suporte import init_db, salvar_log
 from pathlib import Path
 import re
+import numpy as np
+
+# Temporary workaround for NumPy 2.x compatibility with chromadb
+if not hasattr(np, "float_"):
+    np.float_ = np.float64
 
 app = Flask(__name__)
 init_db()


### PR DESCRIPTION
## Summary
- add runtime patch so `np.float_` is available for chromadb

## Testing
- `python -m py_compile app.py log_suporte.py`

------
https://chatgpt.com/codex/tasks/task_e_686ed6591ec48332920df3e546e1d1fb