### PR TITLE
Fix retrieval chain type

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ prompt = PromptTemplate.from_template(template)
 qa = RetrievalQA.from_chain_type(
     llm=llm,
     retriever=retriever,
-    chain_type="map_reduce",
+    chain_type="stuff",
     chain_type_kwargs={"prompt": prompt}
 )
 


### PR DESCRIPTION
## Summary
- fix error when building `RetrievalQA` by switching to the `stuff` chain type

## Testing
- `python -m py_compile app.py log_suporte.py`


------
https://chatgpt.com/codex/tasks/task_e_686facd04e6c8332a1e1c2a0e6a417a3