### PR TITLE
Fix document path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ollama Documentation Chatbot
 
-This project provides a simple Flask web application that lets you chat in Portuguese with an assistant named **C3PO**. The assistant answers questions based on the contents of `documentacao.txt`, using [LangChain](https://python.langchain.com/) and the Ollama `gemma:2b` model.
+This project provides a simple Flask web application that lets you chat in Portuguese with an assistant named **C3PO**. The assistant answers questions based on the contents of `documentacao_estruturada.txt`, using [LangChain](https://python.langchain.com/) and the Ollama `gemma:2b` model.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- update README to point to `documentacao_estruturada.txt`

## Testing
- `python -m py_compile app.py log_suporte.py`


------
https://chatgpt.com/codex/tasks/task_e_686fb14c3e08833280d3a1daa31d165c