### PR TITLE
Fix README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ollama Documentation Chatbot
 
-This project provides a simple Flask web application that lets you chat in Portuguese with an assistant named **C3PO**. The assistant answers questions based on the contents of `documentacao_estruturada.txt`, using [LangChain](https://python.langchain.com/) and the Ollama `gemma:2b` model.
+This project provides a simple Flask web application that lets you chat in Portuguese with an assistant named **C3PO**. The assistant answers questions based on the contents of `documentacao_estruturada.txt`, using [LangChain](https://python.langchain.com/) and the Ollama `gemma:2b` model. The manual is stored in this file and is automatically loaded when the application starts.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- clarify where documentation file gets loaded

## Testing
- `python -m py_compile app.py log_suporte.py`

------
https://chatgpt.com/codex/tasks/task_e_686fb075f1088332a2a7d3735d322785