### PR TITLE
Use environment variables for Ollama settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This project provides a simple Flask web application that lets you chat in Portu
 
 Make sure you have the Ollama service running locally with the `mistral` model available.
 
+### Environment variables
+
+The application reads a few settings from environment variables:
+
+```bash
+export OLLAMA_BASE_URL="http://localhost:11434"  # URL of the Ollama service
+export OLLAMA_MODEL="mistral"                    # Model to load
+export FLASK_DEBUG=1                             # Enable Flask debug mode
+```
+
+If these variables are not set, the values above are used by default.
+
 ## Running the application
 
 Start the Flask server with:

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from langchain.prompts import PromptTemplate
 from log_suporte import init_db, salvar_log
 from pathlib import Path
 import re
+from config import OLLAMA_BASE_URL, OLLAMA_MODEL, FLASK_DEBUG
 
 app = Flask(__name__)
 init_db()
@@ -17,7 +18,7 @@ with open(arquivo_manual, "r", encoding="utf-8") as f:
     manual_text = f.read()
 
 # Modelo Ollama
-llm = ChatOllama(model="mistral", base_url="http://localhost:11434")
+llm = ChatOllama(model=OLLAMA_MODEL, base_url=OLLAMA_BASE_URL)
 
 # Prompt restritivo e direto com o manual incorporado
 template = (
@@ -56,4 +57,4 @@ def index():
     return render_template("index.html", resposta=resposta)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=FLASK_DEBUG)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+
+# Base URL for the Ollama service
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
+# Name of the model to use
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "mistral")
+
+# Enable Flask debug mode when set to a truthy value
+FLASK_DEBUG = os.getenv("FLASK_DEBUG", "false").lower() in ("1", "true", "yes")


### PR DESCRIPTION
## Summary
- add `config.py` that reads OLLAMA_BASE_URL, OLLAMA_MODEL and FLASK_DEBUG from env vars
- use these settings in `app.py`
- document required environment variables in README

## Testing
- `python -m py_compile app.py config.py log_suporte.py`

------
https://chatgpt.com/codex/tasks/task_e_6871505f2f688332bb0b98ec415369b0