### PR TITLE
Add production guidance and env based debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ The app will be available at `http://127.0.0.1:5000/` by default.
 ## Web interface
 
 The homepage displays a chat box where you can type a question about the Nexxo platform. When you submit your question, the page shows the assistant's answer below the form. All interactions are stored in `db.sqlite` for later reference.
+
+## Production deployment
+
+For production environments, run the application with a WSGI server such as [Gunicorn](https://gunicorn.org/):
+
+```bash
+gunicorn app:app
+```
+
+When using Gunicorn, the `if __name__ == "__main__":` block in `app.py` is not executed.
+Make sure the environment variable `FLASK_DEBUG` is unset or set to `0` so that debug mode is disabled in production.

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from log_suporte import init_db, salvar_log
 from pathlib import Path
 import logging
 import re
-from config import OLLAMA_BASE_URL, OLLAMA_MODEL, FLASK_DEBUG
+from config import OLLAMA_BASE_URL, OLLAMA_MODEL
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -65,4 +65,6 @@ def index():
     return render_template("index.html", resposta=resposta, manual_error=manual_error)
 
 if __name__ == "__main__":
-    app.run(debug=FLASK_DEBUG)
+    import os
+    debug_flag = os.getenv("FLASK_DEBUG", "false").lower() in ("1", "true", "yes")
+    app.run(debug=debug_flag)


### PR DESCRIPTION
## Summary
- explain how to run the app with gunicorn for production
- disable Flask debug via environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68716285ba54833297b2c84d354d3523