### PR TITLE
Fix numpy version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ langchain==0.3.26
 langchain-community==0.3.27
 langchain-ollama==0.3.3
 chromadb==0.5.0
-numpy>=2.1.0
+numpy==2.1.0


### PR DESCRIPTION
## Summary
- pin numpy version in requirements

## Testing
- `python -m py_compile app.py config.py log_suporte.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68716390a9d483328492abb3abea5b00